### PR TITLE
feat: Use private config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The library has a default configuration. However, these settings can be changed 
 | Environment Variable | Default | Description |
 | -------------------- | ------- | ----------- |
 | SUITE | golium | Suite name (for logging purposes) | 
-| ENVIRONMENT | local | Name of the environment. Golium reads the environment configuration from the file `${DIR_ENVIRONMENTS}/${ENVIRONMENT}.yml`. This configuration is mandatory and is made available to steps with the function `GetEnvironment()`. |
+| ENVIRONMENT | local | Name of the environment. Golium reads the environment configuration from the file `${DIR_ENVIRONMENTS}/${ENVIRONMENT}.yml`. This configuration is mandatory. An optional configuration file to separate sensitive data can be placed at `${DIR_ENVIRONMENTS}/${ENVIRONMENT}-private.yml`. Configuration is available to steps with the function `GetEnvironment()`. |
 | DIR_SCHEMAS | ./schemas | Directory where the JSON schemas are available. These JSON schemas are used by some steps to validate some output (e.g. the body of the HTTP response). |
 | DIR_ENVIRONMENTS | ./environments | Directory where the configuration for each environment is available. Each environment must have a yml file in this directory. |
 | LOG_DIRECTORY | ./logs | Directory where logs are written. There may be multiple log files. Currently, there is one for tracing the execution of the steps and scenarios (golium.log) and another one to save the HTTP requests and HTTP responses (http.log). |

--- a/config.go
+++ b/config.go
@@ -45,15 +45,21 @@ func GetEnvironment() Map {
 	return environment
 }
 
-// Load the environment configuration from a yml file.
-// The environment configuration is obtained from a yml file located at:
+// Load the environment configuration from yml files.
+// The mandatory environment configuration file is obtained from yml file located at:
 //    {config.Dir.Enviroments}/{config.Environment}.yml
+// An optional environment configuration file to allow hide or crypt sensitive data could be located at:
+//    {config.Dir.Enviroments}/{config.Environment}-private.yml
 func initEnvironment() Map {
-	path := path.Join(config.Dir.Environments, fmt.Sprintf("%s.yml", config.Environment))
-	logrus.Infof("Loading environment configuration from file: %s", path)
+	pathEnv := path.Join(config.Dir.Environments, fmt.Sprintf("%s.yml", config.Environment))
+	logrus.Infof("Loading environment configuration from file: %s", pathEnv)
 	env := make(map[string]interface{})
-	if err := cfg.LoadYaml(path, &env); err != nil {
-		logrus.Fatalf("Error loading environment configuration from file: %s. %s", path, err)
+	if err := cfg.LoadYaml(pathEnv, &env); err != nil {
+		logrus.Fatalf("Error loading environment configuration from file: %s. %s", pathEnv, err)
+	}
+	pathEnvPrivate := path.Join(config.Dir.Environments, fmt.Sprintf("%s-private.yml", config.Environment))
+	if err := cfg.LoadYaml(pathEnvPrivate, &env); err != nil {
+		logrus.Infof("Could not load private environment configuration from file: %s. %s", pathEnvPrivate, err)
 	}
 	b, err := json.Marshal(env)
 	if err != nil {


### PR DESCRIPTION
Define environment parameterization by two files:  env.yml  and env-private.yml to allow separate sensitive data in the environment configuration