### PR TITLE
bug: remove port from step to store local ipv4/ipv6

### DIFF
--- a/steps/common/steps.go
+++ b/steps/common/steps.go
@@ -175,6 +175,6 @@ func getLocalIP(ctx context.Context, key string, ipVersion IPVersion) error {
 	if localAddress == nil {
 		return errors.New("couldn't find local IP")
 	}
-	golium.GetContext(ctx).Put(golium.ValueAsString(ctx, key), localAddress.String())
+	golium.GetContext(ctx).Put(golium.ValueAsString(ctx, key), localAddress.IP.String())
 	return nil
 }


### PR DESCRIPTION
After modifying step to store local ip in v4 and v6 formats, port is been added..