### PR TITLE
4224 fix: [GOLIUM][TECHDEBT] Check rabbitmq step to filter messages by standard properties

### DIFF
--- a/steps/rabbit/session.go
+++ b/steps/rabbit/session.go
@@ -316,7 +316,7 @@ func (s *Session) WaitForMessagesWithStandardProperties(
 			return err
 		}
 
-		count = s.processReceivedMessages(ctx, props, unconsumedMessages, &processedMessagesCount, count)
+		count = s.processReceivedMessages(props, unconsumedMessages, &processedMessagesCount, count)
 		if count == 0 {
 			return nil
 		}
@@ -330,7 +330,6 @@ func (s *Session) WaitForMessagesWithStandardProperties(
 }
 
 func (s *Session) processReceivedMessages(
-	ctx context.Context,
 	props amqp.Delivery,
 	unconsumedMessages []amqp.Delivery,
 	processedMessagesCount *int,

--- a/steps/rabbit/session.go
+++ b/steps/rabbit/session.go
@@ -320,7 +320,7 @@ func (s *Session) WaitForMessagesWithStandardProperties(
 			return err
 		}
 
-		count = s.processReceivedMessages(props, unconsumedMessages, &processedMessagesCount, count)
+		count = s.processReceivedMessages(props, &unconsumedMessages, &processedMessagesCount, count)
 		if count == 0 {
 			return nil
 		}
@@ -333,7 +333,7 @@ func (s *Session) WaitForMessagesWithStandardProperties(
 
 	// ensures that if there are messages to be processed, none of them match the standard properties
 	if err == nil && strictly {
-		count = s.processReceivedMessages(props, unconsumedMessages, &processedMessagesCount, count)
+		count = s.processReceivedMessages(props, &unconsumedMessages, &processedMessagesCount, count)
 		if count < 0 {
 			err = fmt.Errorf("more than expected message(s) received match(es) the standard properties")
 		}
@@ -344,7 +344,7 @@ func (s *Session) WaitForMessagesWithStandardProperties(
 
 func (s *Session) processReceivedMessages(
 	props amqp.Delivery,
-	unconsumedMessages []amqp.Delivery,
+	unconsumedMessages *[]amqp.Delivery,
 	processedMessagesCount *int,
 	count int,
 ) int {
@@ -362,7 +362,7 @@ func (s *Session) processReceivedMessages(
 				break
 			}
 		} else {
-			unconsumedMessages = append(unconsumedMessages, s.Messages[i])
+			*unconsumedMessages = append(*unconsumedMessages, s.Messages[i])
 		}
 	}
 

--- a/steps/rabbit/session.go
+++ b/steps/rabbit/session.go
@@ -341,7 +341,7 @@ func (s *Session) processReceivedMessages(
 		logrus.Debugf("Checking message: %s", s.Messages[i].Body)
 		*processedMessagesCount++
 
-		errValidate := s.validateMessageStandardProperties(ctx, s.Messages[i], props)
+		errValidate := s.validateMessageStandardProperties(s.Messages[i], props)
 		if errValidate == nil {
 			s.msg = s.Messages[i]
 			s.ConsumedMessages = append(s.ConsumedMessages, s.Messages[i])
@@ -360,14 +360,12 @@ func (s *Session) processReceivedMessages(
 // ValidateMessageStandardProperties checks if the message standard rabbit properties are equal
 // the expected values.
 func (s *Session) ValidateMessageStandardProperties(
-	ctx context.Context,
 	props amqp.Delivery,
 ) error {
-	return s.validateMessageStandardProperties(ctx, s.msg, props)
+	return s.validateMessageStandardProperties(s.msg, props)
 }
 
 func (s *Session) validateMessageStandardProperties(
-	ctx context.Context,
 	msgToValidate amqp.Delivery,
 	props amqp.Delivery,
 ) error {

--- a/steps/rabbit/session_test.go
+++ b/steps/rabbit/session_test.go
@@ -564,7 +564,7 @@ func TestWaitForMessagesWithStandardProperties(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Not all expected messages matching the standard properties have been received",
+			name: "Not matching number of received messages with standard properties",
 			args: args{
 				count:    2,
 				messages: []amqp.Delivery{{Priority: 10}, {Priority: 5}},
@@ -575,7 +575,7 @@ func TestWaitForMessagesWithStandardProperties(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Not all expected messages matching the standard properties have been received expecting error",
+			name: "Not matching number of received messages with standard properties expecting error",
 			args: args{
 				count:    2,
 				messages: []amqp.Delivery{{Priority: 10}, {Priority: 5}},

--- a/steps/rabbit/steps.go
+++ b/steps/rabbit/steps.go
@@ -66,15 +66,15 @@ func (cs Steps) InitializeSteps(ctx context.Context, scenCtx *godog.ScenarioCont
 	})
 	scenCtx.Step(`^I wait up to "(\d+)" seconds? for a rabbit message with the standard properties$`, func(timeout int, t *godog.Table) error {
 		timeoutDuration := time.Duration(timeout) * time.Second
-		return session.WaitForMessagesWithStandardProperties(ctx, timeoutDuration, 1, t, false)
+		return session.WaitForMessagesWithStandardProperties(ctx, timeoutDuration, 1, false, t, false)
 	})
-	scenCtx.Step(`^I wait up to "(\d+)" seconds? for "(\d+)" rabbit messages with the standard properties$`, func(timeout int, count int, t *godog.Table) error {
+	scenCtx.Step(`^I wait up to "(\d+)" seconds? for exactly "(\d+)" rabbit messages with the standard properties$`, func(timeout int, count int, t *godog.Table) error {
 		timeoutDuration := time.Duration(timeout) * time.Second
-		return session.WaitForMessagesWithStandardProperties(ctx, timeoutDuration, count, t, false)
+		return session.WaitForMessagesWithStandardProperties(ctx, timeoutDuration, count, true, t, false)
 	})
 	scenCtx.Step(`^I wait up to "(\d+)" seconds? without a rabbit message with the standard properties$`, func(timeout int, t *godog.Table) error {
 		timeoutDuration := time.Duration(timeout) * time.Second
-		return session.WaitForMessagesWithStandardProperties(ctx, timeoutDuration, 1, t, true)
+		return session.WaitForMessagesWithStandardProperties(ctx, timeoutDuration, 1, false, t, true)
 	})
 	scenCtx.Step(`^the rabbit message has the rabbit headers$`, func(t *godog.Table) error {
 		return session.ValidateMessageHeaders(ctx, t)

--- a/steps/rabbit/steps.go
+++ b/steps/rabbit/steps.go
@@ -84,7 +84,7 @@ func (cs Steps) InitializeSteps(ctx context.Context, scenCtx *godog.ScenarioCont
 		if err := golium.ConvertTableWithoutHeaderToStruct(ctx, t, &props); err != nil {
 			return fmt.Errorf("failed configuring rabbit endpoint: %w", err)
 		}
-		return session.ValidateMessageStandardProperties(ctx, props)
+		return session.ValidateMessageStandardProperties(props)
 	})
 	scenCtx.Step(`^the rabbit message body has the text$`, func(m *godog.DocString) error {
 		message := golium.ValueAsString(ctx, m.Content)

--- a/test/acceptance/features/rabbit.feature
+++ b/test/acceptance/features/rabbit.feature
@@ -73,7 +73,7 @@ Feature: Rabbit client
           | param | value   |
           | id2   | abc2    |
           | name2 | Golium2 |
-     Then I wait up to "5" seconds for "3" rabbit messages with the standard properties
+     Then I wait up to "5" seconds for exactly "3" rabbit messages with the standard properties
           | param         | value                |
           | ContentType   | application/json     |
           | CorrelationId | [CTXT:CorrelationId] |


### PR DESCRIPTION
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:

- Added a counter that checks that all expected messages have been received in the asigned time.
- All the steps that wait a while until the conditions described are met, "consume" the messages from the slice that stores them all.
- Post-wait validation steps are performed on "consumed" messages.
- Added new tests.

Explain the **details** for making this change. What existing problem does the pull request solve?

The step "And I wait up to "X" seconds for "Y" rabbit messages with the standard properties" only checks that at least one message that meets the conditions has been received.
