### PR TITLE
5420 fix: [GOLIUM] Missing return value received when using slices.Delete

### DIFF
--- a/steps/rabbit/session.go
+++ b/steps/rabbit/session.go
@@ -212,7 +212,7 @@ func (s *Session) WaitForTextMessage(ctx context.Context,
 
 				// Consume the processed messages
 				s.ConsumedMessages = append(s.ConsumedMessages, s.Messages[i])
-				slices.Delete(s.Messages, i, i+1)
+				s.Messages = slices.Delete(s.Messages, i, i+1)
 
 				return nil
 			}
@@ -245,7 +245,7 @@ func (s *Session) WaitForJSONMessageWithProperties(ctx context.Context,
 
 				// Consume the processed messages
 				s.ConsumedMessages = append(s.ConsumedMessages, s.Messages[i])
-				slices.Delete(s.Messages, i, i+1)
+				s.Messages = slices.Delete(s.Messages, i, i+1)
 
 				return nil
 			}

--- a/test/acceptance/features/rabbit.feature
+++ b/test/acceptance/features/rabbit.feature
@@ -3,138 +3,255 @@ Feature: Rabbit client
   @rabbit
   Scenario: Publish and subscribe a text message
     Given the rabbit endpoint "[CONF:rabbitmq]"
-      And I subscribe to the rabbit topic "test-rabbit-text-properties-topic"
-     When I publish a message to the rabbit topic "test-rabbit-text-properties-topic" with the text
+    And I subscribe to the rabbit topic "test-rabbit-text-properties-topic"
+    When I publish a message to the rabbit topic "test-rabbit-text-properties-topic" with the text
           """
           This is a test message
           """
-     Then I wait up to "3" seconds for a rabbit message with the text
+    Then I wait up to "3" seconds for a rabbit message with the text
           """
           This is a test message
+          """
+
+  @rabbit
+  Scenario: Publish, subscribe and consume two text messages
+    Given the rabbit endpoint "[CONF:rabbitmq]"
+    And I subscribe to the rabbit topic "test-rabbit-text-properties-topic"
+    When I publish a message to the rabbit topic "test-rabbit-text-properties-topic" with the text
+          """
+          This is a test message
+          """
+    And  I publish a message to the rabbit topic "test-rabbit-text-properties-topic" with the text
+          """
+          This is a second test message
+          """
+    Then I wait up to "3" seconds for a rabbit message with the text
+          """
+          This is a test message
+          """
+    And I wait up to "3" seconds for a rabbit message with the text
+          """
+          This is a second test message
           """
 
   @rabbit
   Scenario: Publish and subscribe a JSON message
     Given the rabbit endpoint "[CONF:rabbitmq]"
-      And I subscribe to the rabbit topic "test-rabbit-json-properties-topic"
-      And I set standard rabbit properties
-          | param         | value                |
-          | ContentType   | application/json     |
-          | CorrelationId | [CTXT:CorrelationId] |
-     When I publish a message to the rabbit topic "test-rabbit-json-properties-topic" with the JSON properties
-          | param | value  |
-          | id    | abc    |
-          | name  | Golium |
-     Then I wait up to "3" seconds for a rabbit message with the JSON properties
-          | param | value  |
-          | id       | abc    |
-          | name     | Golium |
+    And I subscribe to the rabbit topic "test-rabbit-json-properties-topic"
+    And I set standard rabbit properties
+      | param         | value                |
+      | ContentType   | application/json     |
+      | CorrelationId | [CTXT:CorrelationId] |
+    When I publish a message to the rabbit topic "test-rabbit-json-properties-topic" with the JSON properties
+      | param | value  |
+      | id    | abc    |
+      | name  | Golium |
+    Then I wait up to "3" seconds for a rabbit message with the JSON properties
+      | param | value  |
+      | id    | abc    |
+      | name  | Golium |
+
+  @rabbit
+  Scenario: Publish, subscribe and consume two JSON messages
+    Given the rabbit endpoint "[CONF:rabbitmq]"
+    And I subscribe to the rabbit topic "test-rabbit-json-properties-topic"
+    And I set standard rabbit properties
+      | param         | value                |
+      | ContentType   | application/json     |
+      | CorrelationId | [CTXT:CorrelationId] |
+    When I publish a message to the rabbit topic "test-rabbit-json-properties-topic" with the JSON properties
+      | param | value  |
+      | id    | abc    |
+      | name  | Golium |
+    And I publish a message to the rabbit topic "test-rabbit-json-properties-topic" with the JSON properties
+      | param | value  |
+      | id    | def    |
+      | name  | Golium |
+    Then I wait up to "3" seconds for a rabbit message with the JSON properties
+      | param | value  |
+      | id    | abc    |
+      | name  | Golium |
+    And I wait up to "3" seconds without a rabbit message with the JSON properties
+      | param | value  |
+      | id    | abc    |
+      | name  | Golium |
+    And I wait up to "3" seconds for a rabbit message with the JSON properties
+      | param | value  |
+      | id    | def    |
+      | name  | Golium |
+    And the rabbit message body has the JSON properties
+      | param | value  |
+      | id    | def    |
+      | name  | Golium |
+    And I wait up to "3" seconds without a rabbit message with the JSON properties
+      | param | value  |
+      | id    | def    |
+      | name  | Golium |
 
   @rabbit
   Scenario: Publish and subscribe a JSON message. Use standard properties
     Given I generate a UUID and store it in context "CorrelationId"
-    Given the rabbit endpoint "[CONF:rabbitmq]"
-      And I subscribe to the rabbit topic "test-rabbit-json-properties-[CTXT:CorrelationId]"
-      And I set standard rabbit properties
-          | param         | value                |
-          | ContentType   | application/json     |
-          | CorrelationId | [CTXT:CorrelationId] |
-     When I publish a message to the rabbit topic "test-rabbit-json-properties-[CTXT:CorrelationId]" with the JSON properties
-          | param | value  |
-          | id    | abc    |
-          | name  | Golium |
-     Then I wait up to "3" seconds for a rabbit message with the standard properties
-          | param         | value                |
-          | ContentType   | application/json     |
-          | CorrelationId | [CTXT:CorrelationId] |
-      And the rabbit message body has the JSON properties
-          | param | value  |
-          | id    | abc    |
-          | name  | Golium |
+    And the rabbit endpoint "[CONF:rabbitmq]"
+    And I subscribe to the rabbit topic "test-rabbit-json-properties-[CTXT:CorrelationId]"
+    And I set standard rabbit properties
+      | param         | value                |
+      | ContentType   | application/json     |
+      | CorrelationId | [CTXT:CorrelationId] |
+    When I publish a message to the rabbit topic "test-rabbit-json-properties-[CTXT:CorrelationId]" with the JSON properties
+      | param | value  |
+      | id    | abc    |
+      | name  | Golium |
+    Then I wait up to "3" seconds for a rabbit message with the standard properties
+      | param         | value                |
+      | ContentType   | application/json     |
+      | CorrelationId | [CTXT:CorrelationId] |
+    And the rabbit message body has the JSON properties
+      | param | value  |
+      | id    | abc    |
+      | name  | Golium |
 
   @rabbit
-  Scenario: Publish and subscribe three JSON messages. Use standard properties
+  Scenario: Publish, subscribe and consume three JSON messages. Use standard properties
     Given I generate a UUID and store it in context "CorrelationId"
-    Given the rabbit endpoint "[CONF:rabbitmq]"
-      And I subscribe to the rabbit topic "test-rabbit-json-properties-[CTXT:CorrelationId]"
-      And I set standard rabbit properties
-          | param         | value                |
-          | ContentType   | application/json     |
-          | CorrelationId | [CTXT:CorrelationId] |
-     When I publish a message to the rabbit topic "test-rabbit-json-properties-[CTXT:CorrelationId]" with the JSON properties
-          | param | value   |
-          | id0   | abc0    |
-          | name0 | Golium0 |
-     When I publish a message to the rabbit topic "test-rabbit-json-properties-[CTXT:CorrelationId]" with the JSON properties
-          | param | value   |
-          | id1   | abc1    |
-          | name1 | Golium1 |
-     When I publish a message to the rabbit topic "test-rabbit-json-properties-[CTXT:CorrelationId]" with the JSON properties
-          | param | value   |
-          | id2   | abc2    |
-          | name2 | Golium2 |
-     Then I wait up to "5" seconds for exactly "3" rabbit messages with the standard properties
-          | param         | value                |
-          | ContentType   | application/json     |
-          | CorrelationId | [CTXT:CorrelationId] |
-      And the body of the rabbit message in position "0" has the JSON properties
-          | param | value   |
-          | id0   | abc0    |
-          | name0 | Golium0 |
-      And the body of the rabbit message in position "1" has the JSON properties
-          | param | value   |
-          | id1   | abc1    |
-          | name1 | Golium1 |
-      And the body of the rabbit message in position "2" has the JSON properties
-          | param | value   |
-          | id2   | abc2    |
-          | name2 | Golium2 |
+    And the rabbit endpoint "[CONF:rabbitmq]"
+    And I subscribe to the rabbit topic "test-rabbit-json-properties-[CTXT:CorrelationId]"
+    And I set standard rabbit properties
+      | param         | value                |
+      | ContentType   | application/json     |
+      | CorrelationId | [CTXT:CorrelationId] |
+    When I publish a message to the rabbit topic "test-rabbit-json-properties-[CTXT:CorrelationId]" with the JSON properties
+      | param | value   |
+      | id0   | abc0    |
+      | name0 | Golium0 |
+    And I publish a message to the rabbit topic "test-rabbit-json-properties-[CTXT:CorrelationId]" with the JSON properties
+      | param | value   |
+      | id1   | abc1    |
+      | name1 | Golium1 |
+    And I publish a message to the rabbit topic "test-rabbit-json-properties-[CTXT:CorrelationId]" with the JSON properties
+      | param | value   |
+      | id2   | abc2    |
+      | name2 | Golium2 |
+    Then I wait up to "5" seconds for exactly "3" rabbit messages with the standard properties
+      | param         | value                |
+      | ContentType   | application/json     |
+      | CorrelationId | [CTXT:CorrelationId] |
+    And the body of the rabbit message in position "0" has the JSON properties
+      | param | value   |
+      | id0   | abc0    |
+      | name0 | Golium0 |
+    And the body of the rabbit message in position "1" has the JSON properties
+      | param | value   |
+      | id1   | abc1    |
+      | name1 | Golium1 |
+    And the body of the rabbit message in position "2" has the JSON properties
+      | param | value   |
+      | id2   | abc2    |
+      | name2 | Golium2 |
+    And I wait up to "3" seconds without a rabbit message with the standard properties
+      | param         | value                |
+      | ContentType   | application/json     |
+      | CorrelationId | [CTXT:CorrelationId] |
+
+  @rabbit
+  Scenario: Publish, subscribe and consume three JSON messages with different CorrelationId. Use standard properties
+    Given I generate a UUID and store it in context "CorrelationId"
+    And I generate a UUID and store it in context "CorrelationId2"
+    And the rabbit endpoint "[CONF:rabbitmq]"
+    And I subscribe to the rabbit topic "test-rabbit-json-properties-[CTXT:CorrelationId]"
+    And I set standard rabbit properties
+      | param         | value                |
+      | ContentType   | application/json     |
+      | CorrelationId | [CTXT:CorrelationId] |
+    When I publish a message to the rabbit topic "test-rabbit-json-properties-[CTXT:CorrelationId]" with the JSON properties
+      | param | value   |
+      | id0   | abc0    |
+      | name0 | Golium0 |
+    And I publish a message to the rabbit topic "test-rabbit-json-properties-[CTXT:CorrelationId]" with the JSON properties
+      | param | value   |
+      | id1   | abc1    |
+      | name1 | Golium1 |
+    And I set standard rabbit properties
+      | param         | value                 |
+      | ContentType   | application/json      |
+      | CorrelationId | [CTXT:CorrelationId2] |
+    And I publish a message to the rabbit topic "test-rabbit-json-properties-[CTXT:CorrelationId]" with the JSON properties
+      | param | value   |
+      | id2   | abc2    |
+      | name2 | Golium2 |
+    Then I wait up to "5" seconds for exactly "2" rabbit messages with the standard properties
+      | param         | value                |
+      | ContentType   | application/json     |
+      | CorrelationId | [CTXT:CorrelationId] |
+    And the body of the rabbit message in position "0" has the JSON properties
+      | param | value   |
+      | id0   | abc0    |
+      | name0 | Golium0 |
+    And the body of the rabbit message in position "1" has the JSON properties
+      | param | value   |
+      | id1   | abc1    |
+      | name1 | Golium1 |
+    And I wait up to "3" seconds without a rabbit message with the standard properties
+      | param         | value                |
+      | ContentType   | application/json     |
+      | CorrelationId | [CTXT:CorrelationId] |
+    And I wait up to "3" seconds for a rabbit message with the standard properties
+      | param         | value                 |
+      | ContentType   | application/json      |
+      | CorrelationId | [CTXT:CorrelationId2] |
+    And the rabbit message body has the JSON properties
+      | param | value   |
+      | id2   | abc2    |
+      | name2 | Golium2 |
+    And I wait up to "3" seconds without a rabbit message with the standard properties
+      | param         | value                 |
+      | ContentType   | application/json      |
+      | CorrelationId | [CTXT:CorrelationId2] |
 
   @rabbit
   Scenario: Publish and subscribe a JSON message with rabbit headers and standard properties
     Given the rabbit endpoint "[CONF:rabbitmq]"
-      And I subscribe to the rabbit topic "test-rabbit-headers-properties-topic"
-      And I set rabbit headers
-          | param   | value  |
-          | Header1 | value1 |
-          | Header2 | value2 |
-     When I publish a message to the rabbit topic "test-rabbit-headers-properties-topic" with the JSON properties
-          | param | value  |
-          | id    | abc    |
-          | name  | Golium |
-     Then I wait up to "3" seconds for a rabbit message with the JSON properties
-          | param | value  |
-          | id    | abc    |
-          | name  | Golium |
-      And the rabbit message has the rabbit headers
-          | param   | value  |
-          | Header1 | value1 |
-          | Header2 | value2 |
+    And I subscribe to the rabbit topic "test-rabbit-headers-properties-topic"
+    And I set rabbit headers
+      | param   | value  |
+      | Header1 | value1 |
+      | Header2 | value2 |
+    When I publish a message to the rabbit topic "test-rabbit-headers-properties-topic" with the JSON properties
+      | param | value  |
+      | id    | abc    |
+      | name  | Golium |
+    Then I wait up to "3" seconds for a rabbit message with the JSON properties
+      | param | value  |
+      | id    | abc    |
+      | name  | Golium |
+    And the rabbit message has the rabbit headers
+      | param   | value  |
+      | Header1 | value1 |
+      | Header2 | value2 |
 
   @rabbit
   Scenario: Publish and subscribe a text message with rabbit headers
     Given the rabbit endpoint "[CONF:rabbitmq]"
-      And I subscribe to the rabbit topic "test-rabbit-headers-topic"
-      And I set rabbit headers
-          | param   | value  |
-          | Header1 | value1 |
-          | Header2 | value2 |
-     When I publish a message to the rabbit topic "test-rabbit-headers-topic" with the text
+    And I subscribe to the rabbit topic "test-rabbit-headers-topic"
+    And I set rabbit headers
+      | param   | value  |
+      | Header1 | value1 |
+      | Header2 | value2 |
+    When I publish a message to the rabbit topic "test-rabbit-headers-topic" with the text
           """
           """
-     Then I wait up to "3" seconds for a rabbit message with the text
+    Then I wait up to "3" seconds for a rabbit message with the text
           """
           """
-      And the rabbit message has the rabbit headers
-          | param   | value  |
-          | Header1 | value1 |
-          | Header2 | value2 |
+    And the rabbit message has the rabbit headers
+      | param   | value  |
+      | Header1 | value1 |
+      | Header2 | value2 |
 
   @rabbit
   Scenario: Subscribe and waits for no message
     Given I generate a UUID and store it in context "CorrelationId"
-    Given the rabbit endpoint "[CONF:rabbitmq]"
-     When I subscribe to the rabbit topic "test-rabbit-empty-topic"
-     Then I wait up to "3" seconds without a rabbit message with the standard properties
-          | param         | value                |
-          | CorrelationId | [CTXT:CorrelationId] |
+    And the rabbit endpoint "[CONF:rabbitmq]"
+    When I subscribe to the rabbit topic "test-rabbit-empty-topic"
+    Then I wait up to "3" seconds without a rabbit message with the standard properties
+      | param         | value                |
+      | CorrelationId | [CTXT:CorrelationId] |


### PR DESCRIPTION
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:

- The value returned by slices.Delete has been assigned to the variable.
- Some tests have been completed to verify that the messages have been consumed.
- Added new tests.

Explain the **details** for making this change. What existing problem does the pull request solve?

When a message was consumed, it was removed from the slice but it still maintained the original length and, therefore, it could contain more elements than expected.

Fixes #119 
